### PR TITLE
Improved Extinf support

### DIFF
--- a/Pantomime.xcodeproj/project.pbxproj
+++ b/Pantomime.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27EDFCB21E9061B400945246 /* media3.m3u8 in Resources */ = {isa = PBXBuildFile; fileRef = 27EDFCB11E9061B400945246 /* media3.m3u8 */; };
 		5ED0327E1D6F1710006DE1F3 /* ManifestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED032791D6F1710006DE1F3 /* ManifestBuilder.swift */; };
 		5ED0327F1D6F1710006DE1F3 /* MediaSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED0327A1D6F1710006DE1F3 /* MediaSegment.swift */; };
 		5ED032801D6F1710006DE1F3 /* MediaPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED0327B1D6F1710006DE1F3 /* MediaPlaylist.swift */; };
@@ -69,6 +70,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		27EDFCB11E9061B400945246 /* media3.m3u8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = media3.m3u8; sourceTree = "<group>"; };
 		5ED032791D6F1710006DE1F3 /* ManifestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ManifestBuilder.swift; path = sources/ManifestBuilder.swift; sourceTree = "<group>"; };
 		5ED0327A1D6F1710006DE1F3 /* MediaSegment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaSegment.swift; path = sources/MediaSegment.swift; sourceTree = "<group>"; };
 		5ED0327B1D6F1710006DE1F3 /* MediaPlaylist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaPlaylist.swift; path = sources/MediaPlaylist.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				9EDCE3F31C09D211002FA4A7 /* PantomimeTests.swift */,
 				7FBCA10A0EB4EAA0CD4AB5EF /* ReaderTests.swift */,
 				7FBCAFC77C9DA4C80FAEA0C2 /* PlaylistTests.swift */,
+				27EDFCB11E9061B400945246 /* media3.m3u8 */,
 			);
 			path = PantomimeTests;
 			sourceTree = "<group>";
@@ -354,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5ED0328F1D6F17BF006DE1F3 /* media2.m3u8 in Resources */,
+				27EDFCB21E9061B400945246 /* media3.m3u8 in Resources */,
 				5ED032961D6F7618006DE1F3 /* master.m3u8 in Resources */,
 				5ED032901D6F17BF006DE1F3 /* media.m3u8 in Resources */,
 			);

--- a/PantomimeTests/PantomimeTests.swift
+++ b/PantomimeTests/PantomimeTests.swift
@@ -10,6 +10,18 @@ import XCTest
 @testable import Pantomime
 
 class PantomimeTests: XCTestCase {
+    
+    func test3ParseMediaPlaylist() {
+        let bundle = Bundle(for: type(of: self))
+        let path = bundle.path(forResource: "media3", ofType: "m3u8")!
+        
+        let manifestBuilder = ManifestBuilder()
+        let mediaPlaylist = manifestBuilder.parseMediaPlaylistFromFile(path)
+        
+        XCTAssert(mediaPlaylist.segments.count == 1)
+        XCTAssert(mediaPlaylist.segments[0].title == "Hey this is working!")
+        XCTAssert(mediaPlaylist.segments[0].properties?["tvg-name"] == "example")
+    }
 
     func testParseMediaPlaylist() {
         let bundle = Bundle(for: type(of: self))
@@ -23,7 +35,7 @@ class PantomimeTests: XCTestCase {
 
         XCTAssert(mediaPlaylist.targetDuration == 10)
         XCTAssert(mediaPlaylist.mediaSequence == 0)
-        XCTAssert(mediaPlaylist.segments.count == 3)
+        XCTAssert(mediaPlaylist.segments.count == 4)
         XCTAssert(mediaPlaylist.segments[0].title == " no desc")
         XCTAssert(mediaPlaylist.segments[0].subrangeLength == 100)
         XCTAssert(mediaPlaylist.segments[0].subrangeStart == 40)

--- a/PantomimeTests/ReaderTests.swift
+++ b/PantomimeTests/ReaderTests.swift
@@ -25,6 +25,8 @@ class ReaderTests: XCTestCase {
             for _ in 1...10 {
                 _ = fileReader.readLine()!
             }
+            XCTAssertEqual("#EXTINF:-1 tvg-ID=\"\" tvg-name=\"example\" custom-attribute=\"\" group-title=\"another example\",title: of channel", fileReader.readLine())
+            XCTAssertEqual("http://media.example.com/fourth.ts", fileReader.readLine())
             XCTAssertNil(fileReader.readLine())
 
             let httpReader = try ReaderBuilder.createReader(.httpreader, reference: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")

--- a/PantomimeTests/media.m3u8
+++ b/PantomimeTests/media.m3u8
@@ -10,3 +10,5 @@ http://media.example.com/first.ts
 http://media.example.com/second.ts
 #EXTINF:3.003,
 http://media.example.com/third.ts
+#EXTINF:-1 tvg-ID="" tvg-name="example" custom-attribute="" group-title="another example",title: of channel
+http://media.example.com/fourth.ts

--- a/PantomimeTests/media3.m3u8
+++ b/PantomimeTests/media3.m3u8
@@ -2,3 +2,5 @@
 #This is a comment
 #EXTINF:-1 tvg-ID="" tvg-name="example" custom-attribute="" group-title="another example",Hey this is working!
 http://media.example.com/fourth.ts
+#EXTINF:-1 tvg-ID="" tvg-name="Kingsman: The Secret Service" tvg-logo="https://images-na.ssl-images-amazon.com/images/M/MV5BMTkxMjgwMDM4Ml5BMl5BanBnXkFtZTgwMTk3NTIwNDE@._V1_SY1000_CR0,0,675,1000_AL_.jpg" group-title="VOD: Action",Kingsman: The Secret Service
+http://client-proiptv.com:8080/movie/AwC7WSEgSy/C1IxqxuT2k/9745.mkv

--- a/PantomimeTests/media3.m3u8
+++ b/PantomimeTests/media3.m3u8
@@ -1,0 +1,4 @@
+#EXTM3U
+#This is a comment
+#EXTINF:-1 tvg-ID="" tvg-name="example" custom-attribute="" group-title="another example",Hey this is working!
+http://media.example.com/fourth.ts

--- a/sources/ManifestBuilder.swift
+++ b/sources/ManifestBuilder.swift
@@ -178,7 +178,7 @@ open class ManifestBuilder {
 
     func getProperties(in text: String) -> [String:String]? {
         do {
-            let regex = try NSRegularExpression(pattern: "([a-zA-z-]*)=\"([a-zA-z0-9 ]*+)\"")
+            let regex = try NSRegularExpression(pattern: "([a-zA-z-]*)=\"(.*?)\"")
             let nsString = text as NSString
             let results = regex.matches(in: text, range: NSRange(location: 0, length: nsString.length))
             let keys = results.map { nsString.substring(with: $0.rangeAt(1))}

--- a/sources/MediaPlaylist.swift
+++ b/sources/MediaPlaylist.swift
@@ -38,6 +38,9 @@ open class MediaPlaylist {
     open func duration() -> Float {
         var dur: Float = 0.0
         for item in segments {
+            if item.duration == nil || item.duration! <= 0 {
+                continue
+            }
             dur = dur + item.duration!
         }
         return dur

--- a/sources/MediaSegment.swift
+++ b/sources/MediaSegment.swift
@@ -14,6 +14,7 @@ open class MediaSegment {
     open var title: String?
     open var discontinuity: Bool = false
     open var path: String?
+    open var properties: [String:String]?
 
     public init() {
 


### PR DESCRIPTION
Thanks for work you've done. Sadly it didn't support my use case. So I made the following changes.

Extinf wouldn't read the title properly, it now does. Also it didn't read the properties sent along, it does now. See:
```
#EXTINF:-1 tvg-ID="" tvg-name="example" custom-attribute="" group-title="another example",title: of channel
http://media.example.com/fourth.ts
```

Also added a unit test for this use case.